### PR TITLE
chore: update netlify-deploy action to solve cache bug

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,12 +11,11 @@ jobs:
 
     steps:
       - name: deploy to preview mode
-        uses: thundermiracle/netlify-deploy@v2.0.2
+        uses: thundermiracle/netlify-deploy@v3.0.1
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN}}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID}}
           deploy-dir: "./public"
-          cache-path: |
+          extra-cache-path: |
             .cache
             public
-            node_modules

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,13 +12,12 @@ jobs:
 
     steps:
       - name: deploy to production mode
-        uses: thundermiracle/netlify-deploy@v2.0.2
+        uses: thundermiracle/netlify-deploy@v3.0.1
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN}}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID}}
           deploy-dir: "./public"
-          cache-path: |
+          extra-cache-path: |
             .cache
             public
-            node_modules
           production: true


### PR DESCRIPTION
I found a cache bug in my github action which is [described here](https://github.com/thundermiracle/netlify-deploy/pull/20).

After updating netlify-deploy to v3 will **really** enable the cache of GatsbyJS(`.cache` & `public` folders), and extremely enhance the speed of the build.

My personal blog's build time was 10mins, and with the new version, it was reduced to 3mins.
Hope this update helps you too.